### PR TITLE
fix(dictfile & co): no more variants pollution

### DIFF
--- a/tests/test_3_convert.py
+++ b/tests/test_3_convert.py
@@ -473,22 +473,12 @@ def test_df_format(tmp_path: Path) -> None:
         output.read_text(encoding="utf-8")
         == r"""@ estre
 : \ɛtʁ\
+& suis
 <html><p><b>Verbe</b></p><ol><li>Définition de 'estre'.</li></ol></html>
 
 @ être
 : \ɛtʁ\ <i>m</i>.
-<html><p><b>Verbe</b></p><ol><li>Définition de 'être'.</li></ol></html>
-
-@ suis
-: <b>estre</b> \ɛtʁ\
-<html><p><b>Verbe</b></p><ol><li>Définition de 'estre'.</li></ol></html>
-
-@ suis
-: <b>suivre</b> \sɥivʁ\
-<html><p><b>Verbe</b></p><ol><li>Définition de 'suivre'.</li></ol></html>
-
-@ suis
-: <b>être</b> \ɛtʁ\ <i>m</i>.
+& suis
 <html><p><b>Verbe</b></p><ol><li>Définition de 'être'.</li></ol></html>
 
 @ suivre
@@ -509,13 +499,13 @@ def test_df_format_variants_different_prefix(tmp_path: Path) -> None:
     être = "".join(formatter.handle_word("être", words))
     suis = "".join(formatter.handle_word("suis", words))
     suivre = "".join(formatter.handle_word("suivre", words))
-    assert suis.count("@ suis") == 3
-    assert ": <b>estre</b>" in suis
-    assert ": <b>suivre</b>" in suis
-    assert ": <b>être</b>" in suis
-    assert "&" not in estre  # Because group prefixes are differents
+    assert "@ suis" not in suis
+    assert ": <b>estre</b>" not in suis
+    assert ": <b>suivre</b>" not in suis
+    assert ": <b>être</b>" not in suis
+    assert estre.count("&") == 1 and "& suis" in estre
     assert "&" not in suis  # Because variant == word
-    assert "&" not in être  # Because group prefixes are differents
+    assert être.count("&") == 1 and "& suis" in être
     assert "& suis" in suivre  # Because group prefixes are the same
 
 

--- a/wikidict/stubs.py
+++ b/wikidict/stubs.py
@@ -1,6 +1,6 @@
 """Type annotations."""
 
-from typing import NamedTuple
+from dataclasses import dataclass
 
 SubDefinition = str | tuple[str, ...]
 Definition = str | tuple[str, ...] | tuple[SubDefinition, ...]
@@ -9,12 +9,14 @@ Parts = tuple[str, ...]
 Variants = dict[str, list[str]]
 
 
-class Word(NamedTuple):
+@dataclass
+class Word:
     pronunciations: list[str]
     genders: list[str]
     etymology: list[Definition]
     definitions: Definitions
     variants: list[str]
+    is_variant: bool = False
 
 
 Words = dict[str, Word]


### PR DESCRIPTION
We are using a mechanism to support variants with different prefixes for Kobo (DictHTML output format). The same mechanism was applied to DictFile and its sub-formats, resulting in dictionaries with lot of "pollution" from variants being included with duplicate definitions.

I think the workaround done for Kobo should not apply to to DictFile, and sub-formats. Moreover, the dictFile format specification allowes variants with different prefixes: cf https://pgaskin.net/dictutil/dictgen/#dictfile-format

Fixes #2473.

@lasconic can I have your input here :pray: I would like to be sure not to break the world with this change in case my understanding would be wrong :)
`test_df_format()` shows clearly the change in the dictionary.
