### PR TITLE
[JA] fix hiragana lookup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "hatchling.build"
 [project]
 name = "wikidict"
 dynamic = ["version"]
+dependencies = [
+    "jaconv>=0.5.0",
+]
 
 [tool.hatch.version]
 path = "wikidict/__init__.py"

--- a/wikidict/convert.py
+++ b/wikidict/convert.py
@@ -27,6 +27,7 @@ from pyglossary.glossary_v2 import ConvertArgs, Glossary
 
 from . import constants, render, utils
 from .stubs import Variants, Word, Words
+from .utils import to_katakana
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -45,7 +46,7 @@ if TYPE_CHECKING:
 #       the Kobo lookup regexp for Japanese words is `(<a name="WORD" />.*</w>)`.
 WORD_TPL_KOBO = Template(
     """\
-<w><p><a name="{{ word }}" /><b>{{ word }}</b>{{ pronunciation }}<br/><br/>
+<w><p><a name="{{ headword }}" /><b>{{ word }}</b>{{ pronunciation }}<br/><br/>
 {%- for pos, pos_definitions in definitions -%}
     {%- if pos.find("|") > -1 -%}
     <b>{{ pos.split("|", 1)[0] }}</b> <i>{{ pos.split("|", 1)[1] }}</i>
@@ -299,8 +300,22 @@ class BaseFormat:
         elif lang_src == "ru" and isinstance(self, MobiFormat) and word.isupper():
             variants.add(word.lower())
 
+        # For Japanese hiragana words, the <a name="..."> needs to be the katakana version
+        # because Kobo normalizes hiragana to katakana when looking up words.
+        # Leaving this out causes the Kobo to completely fail to find entries for hiragana words
+        # (see #2750)
+        # Inspiration: https://github.com/cessen/kobo_jp_dict/blob/2f14c08dbd6e5dfb7f3bc95bace6ecead3a8ddb5/src/generic_dict.rs#L334-L337
+        # e.g. for the hiragana entry "あい", we have to generate
+        # <a name="アイ"> with the katakana version, but still display the text as あい
+        # アイ.html: <w><p><a name="アイ" /><b>あい</b>...</p></w>
+        if lang_src == "ja":
+            headword = to_katakana(word)
+        else:
+            headword = word
+
         yield self.render_word(
             self.template,
+            headword=headword,
             word=word,
             definitions=details.definitions.items(),
             pronunciation=utils.convert_pronunciation(details.pronunciations),

--- a/wikidict/utils.py
+++ b/wikidict/utils.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import regex
 import wikitextparser
+import jaconv
 
 from . import constants, context, lang, part_of_speech, svg
 from .hiero_utils import render_hiero
@@ -326,8 +327,14 @@ def is_cyrillic(char: str) -> bool:
 
 
 @cache
-def is_japanese_hiragana(char: str) -> bool:
+def is_japanese_kana(char: str) -> bool:
+    # hiragana is U+3040 - U+309F, katakana is U+30A0 - U+30FF
     return "\u3040" <= char <= "\u30ff"
+
+
+@cache
+def to_katakana(s):
+    return jaconv.hira2kata(s)
 
 
 @cache
@@ -642,8 +649,8 @@ def guess_prefix(word: str, *, locale: str = "") -> str:
         return "" if prefix[-1] == "/" else prefix
 
     if locale == "ja":
-        if is_japanese_hiragana(prefix[0]):
-            return prefix
+        if is_japanese_kana(prefix[0]):
+            return to_katakana(prefix)
 
         if is_japanese_or_chinese(prefix[0]):
             return prefix[0]


### PR DESCRIPTION
Closes #2750.

Convert Japanese hiragana words to katakana for `<a name="..." />` entries and `{prefix}.html` filenames.

- Add `jaconv` package for hiragana->katana conversion
- Make the `<a name="..." />` katakana
- Convert prefix name to katakana . e.g. `あいさつ` -> `あい` -> `アイ`

For Japanese hiragana words, the `<a name="...">` needs to be the katakana version because Kobo normalizes hiragana to katakana when looking up words. Leaving this out causes the Kobo to completely fail to find entries for hiragana words

Inspiration: https://github.com/cessen/kobo_jp_dict/blob/2f14c08dbd6e5dfb7f3bc95bace6ecead3a8ddb5/src/generic_dict.rs#L334-L337

Tested with these words:
- あい (ai, hiragana), アイ (katakana)
- サボる (saboru, mixed hiragana-katakana), サボル (katakana)
- あらわれる (arawareru, hiragana), アラワレル (katakana)